### PR TITLE
[BUG FIX] Event creation now doesnt triggers multiple times

### DIFF
--- a/src/pages/CreateEvent.tsx
+++ b/src/pages/CreateEvent.tsx
@@ -24,13 +24,8 @@ export function CreateEvent() {
   // Prevent duplicate submissions
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const handleSubmit = useCallback(async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    // Guard against multiple submissions
-    if (isSubmitting) {
-      return
-    }
+  const handleSubmit = useCallback(async () => {
+    if (isSubmitting) return
 
     setIsSubmitting(true)
 


### PR DESCRIPTION
# Fixes #47 

Fixeed Duplicate Event Creation Bug
Added isSubmitting state with useCallback hook to prevent duplicate form submissions. Updated submit button with disabled state and loading text feedback.

The main issue was that the `handleSubmit` function in `CreateEvent.tsx` had no protection against multiple submissions.